### PR TITLE
Simplified player move event handling.  Should improve performance.

### DIFF
--- a/src/com/palmergames/bukkit/towny/event/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/event/TownyPlayerListener.java
@@ -200,16 +200,16 @@ public class TownyPlayerListener implements Listener {
 		}
 
 		Player player = event.getPlayer();
-		Location from;
-		try {
-			from = plugin.getCache(player).getLastLocation();
-		} catch (NullPointerException e) {
-			from = event.getFrom();
-		}
+		Location from = event.getFrom();
 		Location to = event.getTo();
 
-		if (from.getBlockX() == to.getBlockX() && from.getBlockY() == to.getBlockY() && from.getBlockZ() == to.getBlockZ())
-			return;
+        if (from.getBlockX() == to.getBlockX()
+                && from.getBlockY() == to.getBlockY()
+                && from.getBlockZ() == to.getBlockZ()
+                && from.getWorld().equals(to.getWorld())) {
+            // Player didn't move by at least one block.
+            return;
+        }
 
 		// Prevent fly/double jump cheats
 		if (!(event instanceof PlayerTeleportEvent)) {


### PR DESCRIPTION
When I originally reviewed the player cached thing a long time back I came to the conclusion that it actually wasn't doing anything.  But I think the purpose is to only bother with player movements if they've only moved a block which this code does much more simply.
