### PR TITLE
Add TeleportCause.COMMAND for /town spawn

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -29,6 +29,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.plugin.Plugin;
 
 import javax.naming.InvalidNameException;
@@ -1086,7 +1087,7 @@ public class TownCommand implements CommandExecutor {
 					player.getVehicle().eject();
 				if (!chunk.isLoaded())
 					chunk.load();
-				player.teleport(spawnLoc);
+				player.teleport(spawnLoc, TeleportCause.COMMAND);
 				return;
 			}
 
@@ -1101,7 +1102,7 @@ public class TownCommand implements CommandExecutor {
 						player.getVehicle().eject();
 					if (!chunk.isLoaded())
 						chunk.load();
-					player.teleport(spawnLoc);
+					player.teleport(spawnLoc, TeleportCause.COMMAND);
 				}
 			}
 		} catch (TownyException e) {


### PR DESCRIPTION
This is a small change to allow other plugins to cancel /town spawn if needed.

I use this in one of my plugins to restrict all forms of warping when underground to make mining more difficult.
