### PR TITLE
MobRemoval Refactor

### DIFF
--- a/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
@@ -18,8 +18,8 @@ import java.util.List;
 public class MobRemovalTimerTask extends TownyTimerTask {
 
 	private Server server;
-	public List<Class> classesOfWorldMobsToRemove = new ArrayList<Class>();
-	public List<Class> classesOfTownMobsToRemove = new ArrayList<Class>();
+	public static List<Class> classesOfWorldMobsToRemove = new ArrayList<Class>();
+	public static List<Class> classesOfTownMobsToRemove = new ArrayList<Class>();
 
 	public MobRemovalTimerTask(Towny plugin, Server server) {
 
@@ -33,7 +33,7 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 	public static List<Class> parseLivingEntityClassNames(List<String> mobClassNames, String errorPrefix) {
 		List<Class> livingEntityClasses = new ArrayList<Class>();
 		for (String mobClassName : mobClassNames) {
-			if (mobClassName.length() == 0) // String.isEmpty()
+			if (mobClassName.isEmpty())
 				continue;
 
 			try {
@@ -51,11 +51,11 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 		return livingEntityClasses;
 	}
 
-	public boolean isRemovingWorldEntity(LivingEntity livingEntity) {
+	public static boolean isRemovingWorldEntity(LivingEntity livingEntity) {
 		return isInstanceOfAny(classesOfWorldMobsToRemove, livingEntity);
 	}
 
-	public boolean isRemovingTownEntity(LivingEntity livingEntity) {
+	public static boolean isRemovingTownEntity(LivingEntity livingEntity) {
 		return isInstanceOfAny(classesOfTownMobsToRemove, livingEntity);
 	}
 
@@ -83,7 +83,7 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 			}
 
 			// Filter worlds not using towny.
-			if (townyWorld.isUsingTowny())
+			if (!townyWorld.isUsingTowny())
 				continue;
 
 			// Filter worlds that will always pass all checks in a world, regardless of possible conditions.
@@ -144,11 +144,11 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 
 				livingEntitiesToRemove.add(livingEntity);
 			}
+		}
 
-			for (LivingEntity livingEntity : livingEntitiesToRemove) {
-				TownyMessaging.sendDebugMsg("MobRemoval Removed: " + livingEntity.toString());
-				livingEntity.remove();
-			}
+		for (LivingEntity livingEntity : livingEntitiesToRemove) {
+			TownyMessaging.sendDebugMsg("MobRemoval Removed: " + livingEntity.toString());
+			livingEntity.remove();
 		}
 	}
 }


### PR DESCRIPTION
Warning, I didn't test this yet. It needs another pair of eyes to make sure the code's logic is the same (I'll relook at it later with a fresh head).

Zonedabone came to complain about MobRemoval being slow in IRC. While he's use case is pretty bad. (I glossed over the fact his db is networked when I was talking too him), he got me to look at the code, and realized it could be better. So I refactored it a little.

I removed the old commented out code (git will keep it in history). I also changed all the negative conditions that got nested up to if (condition) continue. I wrote a function to abstract away the copy pasted code for world + town mob classes. I also removed the wacko string comparison...

```
+  public static boolean isInstanceOfAny(List<Class> classList, Object obj) {
+    for (Class c : classList)
+      if (c.isInstance(obj))
         return true;
-      else if (c.getName().contains(livingEntity.toString()))
-        System.out.print(livingEntity.toString());
     return false;
   }

<Zren> The only time this part would fire is if...
<Zren> You were removing, Spider, but not WolfSpider or something. But WolfSpider doesn't inherit Spider/
<Zren> Ew. Delete!
```

His use case isn't really the norm. Network latency wouldn't spike his CPU. He's use case doesn't work (I only just though of it now) as we remove mobs in the unclaimed areas as well.

The only way to improve on this would be for massive scaled dbs where map lookups would be incredibly slow. And we'd have to break all of the towny checks out of the main thread. That creates a whole buttload of threading fun. If that were the case, it'd be better to move this to a LivingEntityMoveEvent (which doesn't exist). And filter it down to a LivingEntityMoveBlockEvent.

IRC Logs:

```
<Zonedabone> It looks like mob removal is taking quite a bit of main thread time.
<Zonedabone> I suggest that it be changed slightly.
<Zonedabone> First, in a separate thread, get a list of all chunks that are towns.
<Zonedabone> Next, in the main thread, iterate over those chnks and delete the right mobs inside them.
<Zonedabone> THis wwould greatly improves speed on our server, as there are many, many chunks with many, many mobs, but very few town chunks
<Zonedabone> At leat thread data source functions
...
<Zonedabone> Towny mob removal on <3k mobs brought our server to 100% cpu on an i7
<Zren> Getting the entities *should* be in the main thread.
...

TownyWorld townyWorld = null;
try {
    townyWorld = TownyUniverse.getDataSource().getWorld(world.getName());
} catch (NotRegisteredException e) {
    // TODO Auto-generated catch block
    e.printStackTrace();
    return;
}

<Zonedabone> Because right now this lookup is being done ~3k times on my server when it could be done 20 times.
<Zonedabone> I don't know how expensive that lookup is, but chances are since we use a network database it's very expensive.
<Zonedabone> Especially for the main thread.
```

Full Logs: http://pastie.org/4288565
