### PR TITLE
attach PlayerMoveEvent to its related PlayerMoveChunkEvent

### DIFF
--- a/src/com/palmergames/bukkit/towny/event/PlayerChangePlotEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/PlayerChangePlotEvent.java
@@ -4,6 +4,7 @@ import com.palmergames.bukkit.towny.object.WorldCoord;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 
 /**
  * Author: Chris H (Zren / Shade)
@@ -14,12 +15,14 @@ public class PlayerChangePlotEvent extends PlayerEvent {
 	private static final HandlerList handlers = new HandlerList();
 	private WorldCoord from;
 	private WorldCoord to;
-
-	public PlayerChangePlotEvent(Player player, WorldCoord from, WorldCoord to) {
+	private PlayerMoveEvent moveEvent;
+	
+	public PlayerChangePlotEvent(Player player, WorldCoord from, WorldCoord to, PlayerMoveEvent moveEvent) {
 
 		super(player);
 		this.from = from;
 		this.to = to;
+		this.moveEvent = moveEvent;
 	}
 
 	public WorldCoord getFrom() {
@@ -27,6 +30,11 @@ public class PlayerChangePlotEvent extends PlayerEvent {
 		return from;
 	}
 
+	public PlayerMoveEvent getMoveEvent() {
+		
+		return moveEvent;
+	}
+	
 	public WorldCoord getTo() {
 
 		return to;

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -336,7 +336,7 @@ public class TownyPlayerListener implements Listener {
 			TownyWorld toWorld = TownyUniverse.getDataSource().getWorld(to.getWorld().getName());
 			WorldCoord toCoord = new WorldCoord(toWorld.getName(), Coord.parseCoord(to));
 			if (!fromCoord.equals(toCoord))
-				onPlayerMoveChunk(player, fromCoord, toCoord, from, to);
+				onPlayerMoveChunk(player, fromCoord, toCoord, from, to, event);
 			else {
 				//plugin.sendDebugMsg("    From: " + fromCoord);
 				//plugin.sendDebugMsg("    To:   " + toCoord);
@@ -492,12 +492,12 @@ public class TownyPlayerListener implements Listener {
 			TownyMessaging.sendErrorMsg(player, cache.getBlockErrMsg());
 	}
 
-	public void onPlayerMoveChunk(Player player, WorldCoord from, WorldCoord to, Location fromLoc, Location toLoc) {
+	public void onPlayerMoveChunk(Player player, WorldCoord from, WorldCoord to, Location fromLoc, Location toLoc, PlayerMoveEvent moveEvent) {
 
 		plugin.getCache(player).setLastLocation(toLoc);
 		plugin.getCache(player).updateCoord(to);
 
-		PlayerChangePlotEvent event = new PlayerChangePlotEvent(player, from, to);
+		PlayerChangePlotEvent event = new PlayerChangePlotEvent(player, from, to, moveEvent);
 		Bukkit.getServer().getPluginManager().callEvent(event);
 	}
 }


### PR DESCRIPTION
This commit adds the original PlayerMoveEvent as a member of the PlayerMoveChunkEvent, it has no direct effect on Towny but allows other plugins to access the event which triggered this one.
