### PR TITLE
Making /t leave Call a TownRemoveResidentEvent

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -1150,7 +1150,7 @@ public class TownCommand implements CommandExecutor {
 		}
 
 		try {
-			town.removeResident(resident);
+			townRemoveResident(town,resident);
 		} catch (EmptyTownException et) {
 			TownyUniverse.getDataSource().removeTown(et.getTown());
 


### PR DESCRIPTION
Changed the way in which a "leave" command is handled from the basic town.remove(resident) to townRemoveResident method, which appends a call for a TownRemoveResidentEvent (which did not previously happen)
