### PR TITLE
added cancellable mob-removal event.

### DIFF
--- a/src/com/palmergames/bukkit/towny/event/MobRemovalEvent.java
+++ b/src/com/palmergames/bukkit/towny/event/MobRemovalEvent.java
@@ -1,0 +1,38 @@
+package com.palmergames.bukkit.towny.event;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.entity.EntityEvent;
+
+import com.palmergames.bukkit.towny.object.TownBlock;
+
+public class MobRemovalEvent extends EntityEvent implements Cancellable {
+	private static final HandlerList handlers = new HandlerList();
+
+	boolean cancelled = false;
+	
+	public MobRemovalEvent(Entity what) {
+		super(what);
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+	
+	@Override
+	public boolean isCancelled() {
+		return cancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean isCancelled) {
+		cancelled = isCancelled;
+	}
+
+}

--- a/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
+++ b/src/com/palmergames/bukkit/towny/tasks/MobRemovalTimerTask.java
@@ -3,6 +3,7 @@ package com.palmergames.bukkit.towny.tasks;
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyMessaging;
 import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.event.MobRemovalEvent;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.*;
 import com.palmergames.util.JavaUtil;
@@ -145,10 +146,14 @@ public class MobRemovalTimerTask extends TownyTimerTask {
 				livingEntitiesToRemove.add(livingEntity);
 			}
 		}
-
+		MobRemovalEvent mobRemovalEvent;
 		for (LivingEntity livingEntity : livingEntitiesToRemove) {
-			TownyMessaging.sendDebugMsg("MobRemoval Removed: " + livingEntity.toString());
-			livingEntity.remove();
+			mobRemovalEvent = new MobRemovalEvent(livingEntity);
+			plugin.getServer().getPluginManager().callEvent(mobRemovalEvent);
+			if (!mobRemovalEvent.isCancelled()) {
+				TownyMessaging.sendDebugMsg("MobRemoval Removed: " + livingEntity.toString());
+				livingEntity.remove();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fire's a cancellable event when towny would remove a mob from a town.  I need this for a boss plugin which will allow a boss to enter a town even if mobs are off. I'm sure there are other uses as well.
