### PR TITLE
Town Status Improvements and Increased RemoveResidentEvent Accuracy v2

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -227,9 +227,23 @@ public class TownyFormatter {
 		// Mayor: MrSand | Bank: 534 coins
 		out.add(Colors.Green + "Mayor: " + Colors.LightGreen + getFormattedName(town.getMayor()));
 
-		// Assistants [2]: Sammy, Ginger
-		if (town.getAssistants().size() > 0)
-			out.addAll(getFormattedResidents("Assistants", town.getAssistants()));
+		List<String> ranklist = new ArrayList<String>();
+		List<Resident> residentss = town.getResidents();
+		List<String> townranks = TownyPerms.getTownRanks();
+		List<Resident> residentwithrank = new ArrayList<Resident>();
+
+		for (String rank : townranks) {
+			for (Resident r : residentss) {
+				
+				if ((r.getTownRanks() != null) && (r.getTownRanks().contains(rank))) {
+					residentwithrank.add(r);
+				}
+			}
+			ranklist.addAll(getFormattedResidents(rank, residentwithrank));
+			residentwithrank.clear();
+		}
+		
+		out.addAll(ranklist);
 
 		// Nation: Azur Empire
 		try {

--- a/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownyAdminCommand.java
@@ -1,6 +1,7 @@
 package com.palmergames.bukkit.towny.command;
 
 import com.palmergames.bukkit.towny.*;
+import com.palmergames.bukkit.towny.event.TownRemoveResidentEvent;
 import com.palmergames.bukkit.towny.exceptions.AlreadyRegisteredException;
 import com.palmergames.bukkit.towny.exceptions.EmptyTownException;
 import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
@@ -547,6 +548,11 @@ public class TownyAdminCommand implements CommandExecutor {
 					try {
 						Resident resident = TownyUniverse.getDataSource().getResident(name);
 						if (!resident.isNPC() && !BukkitTools.isOnline(resident.getName())) {
+							try{
+								Town town=resident.getTown();
+								BukkitTools.getPluginManager().callEvent(new TownRemoveResidentEvent(resident, town));
+							}
+							catch(NotRegisteredException e){ }
 							TownyUniverse.getDataSource().removeResident(resident);
 							TownyUniverse.getDataSource().removeResidentList(resident);
 							TownyMessaging.sendGlobalMessage(TownySettings.getDelResidentMsg(resident));

--- a/src/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
+++ b/src/com/palmergames/bukkit/towny/tasks/ResidentPurge.java
@@ -6,7 +6,10 @@ import org.bukkit.command.CommandSender;
 
 import com.palmergames.bukkit.towny.Towny;
 import com.palmergames.bukkit.towny.TownyMessaging;
+import com.palmergames.bukkit.towny.event.TownRemoveResidentEvent;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
 import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.Town;
 import com.palmergames.bukkit.towny.object.TownyUniverse;
 import com.palmergames.bukkit.util.BukkitTools;
 
@@ -41,6 +44,11 @@ public class ResidentPurge extends Thread {
 			if (!resident.isNPC() && (System.currentTimeMillis() - resident.getLastOnline() > (this.deleteTime)) && !BukkitTools.isOnline(resident.getName())) {
 				count++;
 				message("Deleting resident: " + resident.getName());
+				try{
+					Town town=resident.getTown();
+					BukkitTools.getPluginManager().callEvent(new TownRemoveResidentEvent(resident, town));
+				}
+				catch(NotRegisteredException e){ }
 				TownyUniverse.getDataSource().removeResident(resident);
 				TownyUniverse.getDataSource().removeResidentList(resident);
 			}


### PR DESCRIPTION
In order for /town to display all ranks as specified in the townyperms file, methods utilized in the /ranklist method have been used in the same location, allowing for a display like:

Mayor: X
Assistant: Y
VIP: Z

With the same formatting otherwise.

Additionally, these commits call RemoveResidentEvents when residents belonging to towns are purged from the system or manually deleted through /ta delete.
