### PR TITLE
Added command /town reslist

### DIFF
--- a/src/com/palmergames/bukkit/towny/TownyFormatter.java
+++ b/src/com/palmergames/bukkit/towny/TownyFormatter.java
@@ -48,6 +48,14 @@ public class TownyFormatter {
 		List<Resident> onlineResidents = TownyUniverse.getOnlineResidentsViewable(player, residentList);
 		return getFormattedResidents(prefix, onlineResidents);
 	}
+	
+	public static List<String> getFormattedResidents(Town town) {
+		List<String> out = new ArrayList<String>();
+		TownyWorld world = town.getWorld();
+		String[] residents = getFormattedNames(town.getResidents().toArray(new Resident[0]));
+		out.addAll(ChatTools.listArr(residents, Colors.Green + "Residents " + Colors.LightGreen + "[" + town.getNumResidents() + "]" + Colors.Green + ":" + Colors.White + " "));
+		return out;
+	}
 
 	public static List<String> getFormattedResidents(String prefix, List<Resident> residentList) {
 

--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -57,6 +57,7 @@ public class TownCommand implements CommandExecutor {
 		output.add(ChatTools.formatCommand("", "/town", "list", ""));
 		output.add(ChatTools.formatCommand("", "/town", "online", TownySettings.getLangString("town_help_10")));
 		output.add(ChatTools.formatCommand("", "/town", "leave", ""));
+		output.add(ChatTools.formatCommand("", "/town", "reslist", ""));
 		output.add(ChatTools.formatCommand("", "/town", "ranklist", ""));
 		output.add(ChatTools.formatCommand("", "/town", "spawn", TownySettings.getLangString("town_help_5")));
 		if (!TownySettings.isTownCreationAdminOnly())
@@ -246,7 +247,19 @@ public class TownCommand implements CommandExecutor {
 						throw new TownyException(TownySettings.getLangString("msg_err_dont_belong_town"));
 					}
 
-				} else if (split[0].equalsIgnoreCase("join")) {
+				} else if (split[0].equalsIgnoreCase("reslist")) {
+
+					if (!TownyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_RESLIST.getNode()))
+						throw new TownyException(TownySettings.getLangString("msg_err_command_disable"));
+
+					try {
+						Resident resident = TownyUniverse.getDataSource().getResident(player.getName());
+						Town town = resident.getTown();
+						TownyMessaging.sendMessage(player, TownyFormatter.getFormattedResidents(town));
+					} catch (NotRegisteredException x) {
+						throw new TownyException(TownySettings.getLangString("msg_err_dont_belong_town"));
+					}
+				}  else if (split[0].equalsIgnoreCase("join")) {
 
 					if (!TownyUniverse.getPermissionSource().testPermission(player, PermissionNodes.TOWNY_COMMAND_TOWN_JOIN.getNode()))
 						throw new TownyException(TownySettings.getLangString("msg_err_command_disable"));

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -172,7 +172,7 @@ public class TownyPlayerListener implements Listener {
 
 		if ((event.getAction() == Action.PHYSICAL)) {
 			if ((block.getType() == Material.SOIL) || (block.getType() == Material.CROPS))
-				if (World.isDisablePlayerTrample()) {
+				if (World.isDisablePlayerTrample() || !PlayerCacheUtil.getCachePermission(player, block.getLocation(), block.getTypeId(), block.getData(), TownyPermission.ActionType.DESTROY)) {
 					event.setCancelled(true);
 					return;
 				}

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -101,6 +101,7 @@ public enum PermissionNodes {
 		
 		TOWNY_COMMAND_TOWN_UNCLAIM("towny.command.town.unclaim"),
 		TOWNY_COMMAND_TOWN_ONLINE("towny.command.town.online"),
+		TOWNY_COMMAND_TOWN_RESLIST("towny.command.town.reslist"),
 	
 	/*
 	 * Plot command permissions

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -159,6 +159,7 @@ permissions:
             towny.command.town.deposit: true
             towny.command.town.rank.*: true
             towny.command.town.ranklist: true
+			towny.command.town.reslist: true
             towny.command.town.set.*: true
             towny.command.town.buy: true
             towny.command.town.toggle.*: true


### PR DESCRIPTION
Added a command to display a list of all users in the player's town without the 35 residents display limit in /town

Note: Please ignore the changes to src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java thats in this request as you have already merged that here.
https://github.com/ElgarL/Towny/pull/67

I'm not sure how I can remove that from this request yet.
