### PR TITLE
_payTo : refund user if the transaction failed.

### DIFF
--- a/src/com/palmergames/bukkit/towny/object/TownyEconomyObject.java
+++ b/src/com/palmergames/bukkit/towny/object/TownyEconomyObject.java
@@ -97,8 +97,7 @@ public class TownyEconomyObject extends TownyObject {
 			if (collector._collect(amount)) {
 				// Transaction failed, refund account.
 				_collect(amount);
-				return false;
-			};
+			}
 			return true;
 		} else {
 			return false;


### PR DESCRIPTION
In function _payTo, if the collector fails to collect the amount then the player should be refunded (to avoid having money vanishing into thin air).
