### PR TITLE
Make output public.

### DIFF
--- a/src/com/palmergames/bukkit/towny/command/TownCommand.java
+++ b/src/com/palmergames/bukkit/towny/command/TownCommand.java
@@ -48,7 +48,7 @@ import static com.palmergames.bukkit.towny.object.TownyObservableType.TOWN_REMOV
 public class TownCommand implements CommandExecutor {
 
 	private static Towny plugin;
-	private static final List<String> output = new ArrayList<String>();
+	public static final List<String> output = new ArrayList<String>();
 
 	static {
 		output.add(ChatTools.formatTitle("/town"));


### PR DESCRIPTION
By making output public, other plugins can hook into Towny.
