### PR TITLE
Add TownyPermissionSource implementation that uses Vault Chat API

### DIFF
--- a/src/com/palmergames/bukkit/towny/Towny.java
+++ b/src/com/palmergames/bukkit/towny/Towny.java
@@ -285,8 +285,24 @@ public class Towny extends JavaPlugin {
 							getTownyUniverse().setPermissionSource(new Perms3Source(this, test));
 							using.add(String.format("%s v%s", "Permissions", test.getDescription().getVersion()));
 						} else {
-							getTownyUniverse().setPermissionSource(new BukkitPermSource(this));
-							using.add("BukkitPermissions");
+							// Try Vault
+							test = getServer().getPluginManager().getPlugin("Vault");
+							if (test != null) {
+								net.milkbowl.vault.chat.Chat chat = getServer().getServicesManager().load(net.milkbowl.vault.chat.Chat.class);
+								if (chat == null) {
+									// No Chat implementation
+									test = null;
+									// Fall back to BukkitPermissions below
+								} else {
+									getTownyUniverse().setPermissionSource(new VaultPermSource(this, chat));
+									using.add(String.format("%s v%s", "Vault", test.getDescription().getVersion()));
+								}
+							}
+
+							if (test == null) {
+								getTownyUniverse().setPermissionSource(new BukkitPermSource(this));
+								using.add("BukkitPermissions");
+							}
 						}
 					}
 				}

--- a/src/com/palmergames/bukkit/towny/permissions/VaultPermSource.java
+++ b/src/com/palmergames/bukkit/towny/permissions/VaultPermSource.java
@@ -1,0 +1,86 @@
+package com.palmergames.bukkit.towny.permissions;
+
+import net.milkbowl.vault.chat.Chat;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.palmergames.bukkit.towny.Towny;
+import com.palmergames.bukkit.towny.TownySettings;
+import com.palmergames.bukkit.towny.object.Resident;
+
+public class VaultPermSource extends TownyPermissionSource {
+
+	private final Chat chat;
+
+	public VaultPermSource(Towny plugin, Chat chat) {
+		this.plugin = plugin;
+		this.chat = chat;
+	}
+
+	@Override
+	public String getPrefixSuffix(Resident resident, String node) {
+		Player player = Bukkit.getPlayerExact(resident.getName());
+		if (player != null) {
+			// Fetch primary group
+			String primaryGroup = getPlayerGroup(player);
+
+			String groupPrefixSuffix = "";
+			String playerPrefixSuffix = "";
+
+			// Pull prefix/suffix for both primary group and player
+			if ("prefix".equalsIgnoreCase(node)) {
+				if (!primaryGroup.isEmpty())
+					groupPrefixSuffix = chat.getGroupPrefix(player.getWorld(), primaryGroup);
+				playerPrefixSuffix = chat.getPlayerPrefix(player);
+			}
+			else if ("suffix".equalsIgnoreCase(node)) {
+				if (!primaryGroup.isEmpty())
+					groupPrefixSuffix = chat.getGroupSuffix(player.getWorld(), primaryGroup);
+				playerPrefixSuffix = chat.getPlayerSuffix(player);
+			}
+
+			// Normalize
+			if (groupPrefixSuffix == null)
+				groupPrefixSuffix = "";
+			if (playerPrefixSuffix == null)
+				playerPrefixSuffix = "";
+
+			// Combine, if different
+			String prefixSuffix = playerPrefixSuffix;
+			if (!playerPrefixSuffix.equals(groupPrefixSuffix))
+				prefixSuffix = groupPrefixSuffix + playerPrefixSuffix;
+
+			return TownySettings.parseSingleLineString(prefixSuffix);
+		}
+		return "";
+	}
+
+	@Override
+	public int getGroupPermissionIntNode(String playerName, String node) {
+		Player player = Bukkit.getPlayerExact(playerName);
+		if (player != null) {
+			String primaryGroup = getPlayerGroup(player);
+
+			if (!primaryGroup.isEmpty())
+				return chat.getGroupInfoInteger(player.getWorld(), primaryGroup, node, -1);
+		}
+		return -1;
+	}
+
+	@Override
+	public String getPlayerGroup(Player player) {
+		String result = chat.getPrimaryGroup(player);
+		return result != null ? result : "";
+	}
+
+	@Override
+	public String getPlayerPermissionStringNode(String playerName, String node) {
+		Player player = Bukkit.getPlayerExact(playerName);
+		if (player != null) {
+			return chat.getPlayerInfoString(player, node, "");
+		}
+		return "";
+	}
+
+}

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -7,7 +7,7 @@ description: >
     Resident-Town-Nation heirarchy combined with a grid based
     protection system. Including a war event.
 
-softdepend: [MultiVerse,Multiverse-Core,XcraftGate,My Worlds,Citizens,PersonalWorlds,WormholeXTremeWorlds]
+softdepend: [MultiVerse,Multiverse-Core,XcraftGate,My Worlds,Citizens,PersonalWorlds,WormholeXTremeWorlds,Vault]
 
 ############################################################
 # +------------------------------------------------------+ #
@@ -370,4 +370,3 @@ permissions:
             towny.command.townyworld.toggle.worldmobs: true
             towny.command.townyworld.toggle.revertunclaim: true
             towny.command.townyworld.toggle.revertexpl: true
-    


### PR DESCRIPTION
This pull request adds a TownyPermissionSource implementation that relies on the Vault Chat API. It is checked before falling back to BukkitPermissions.

This should allow Towny to support all/most of the chat/permissions plugins that Vault does.
