### PR TITLE
Fixed a crash when shooting an Hanging entity.

### DIFF
--- a/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyEntityListener.java
@@ -538,7 +538,7 @@ public class TownyEntityListener implements Listener {
 			}
 
 			if (remover instanceof Player) {
-				Player player = (Player) evt.getRemover();
+				Player player = (Player) remover;
 
 				// Get destroy permissions (updates if none exist)
 				boolean bDestroy = PlayerCacheUtil.getCachePermission(player, hanging.getLocation(), 321, (byte) 0, TownyPermission.ActionType.DESTROY);


### PR DESCRIPTION
The event (falsely) assumed on line #541 that the evt.getRemover was a player. A safeguard was implemented, but not completely.
