### PR TITLE
Added bed spawn command use and permission node.

### DIFF
--- a/src/ChangeLog.txt
+++ b/src/ChangeLog.txt
@@ -1869,3 +1869,9 @@ v0.84.0.9:
 	- Fix negative nation upkeep problems when using Vault.
 v0.84.0.10:
 	- Force shoptax, plottax and embassytax to obey the max tax setting in the config.
+v0.84.0.11:
+	- Add config setting to restrict beduse to personally-owned plots only. Found in Resident Settings @ Deny_Bed_Use.
+	- If deny_bed_use is true and town_respawn is true, a player will respawn at their bed if there is a bed spawn set.
+	- Added new permission node: towny.command.resident.spawn - Allows players to use /resident spawn command.
+	- Added new command: /resident spawn - If deny_bed_use: true and player has a current bed spawn, command will teleport player to their bed.
+	  Behaves according to town spawn command's costs and rules.

--- a/src/com/palmergames/bukkit/config/ConfigNodes.java
+++ b/src/com/palmergames/bukkit/config/ConfigNodes.java
@@ -796,6 +796,10 @@ public enum ConfigNodes {
 			"resident_settings.default_town_name",
 			"",
 			"# The name of the town a resident will automatically join when he first registers."),
+	RES_SETTING_DENY_BED_USE(
+			"resident_settings.deny_bed_use",
+			"false",
+			"# If true, players can only use beds in plots they personally own."),
 	ECO(
 			"economy",
 			"",

--- a/src/com/palmergames/bukkit/towny/TownySettings.java
+++ b/src/com/palmergames/bukkit/towny/TownySettings.java
@@ -788,6 +788,11 @@ public class TownySettings {
 		return getSeconds(ConfigNodes.RES_SETTING_INACTIVE_AFTER_TIME);
 	}
 
+	public static boolean getBedUse() {
+
+		return getBoolean(ConfigNodes.RES_SETTING_DENY_BED_USE);
+	}
+
 	public static String getLoadDatabase() {
 
 		return getString(ConfigNodes.PLUGIN_DATABASE_LOAD);

--- a/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
+++ b/src/com/palmergames/bukkit/towny/listeners/TownyPlayerListener.java
@@ -103,8 +103,12 @@ public class TownyPlayerListener implements Listener {
 			// Check if only respawning in the same world as the town's spawn.
 			if (TownySettings.isTownRespawningInOtherWorlds() && !player.getWorld().equals(respawn.getWorld()))
 				return;
-
-			event.setRespawnLocation(respawn);
+			
+			if (TownySettings.getBedUse() && player.getBedSpawnLocation() != null)
+				event.setRespawnLocation(player.getBedSpawnLocation());
+			else 
+				event.setRespawnLocation(respawn);
+			
 		} catch (TownyException e) {
 			// Town has not set respawn location. Using default.
 		}
@@ -423,6 +427,22 @@ public class TownyPlayerListener implements Listener {
 		TownyPerms.assignPermissions(null, event.getPlayer());
 	}
 
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onPlayerBedEnter(PlayerBedEnterEvent event) {
+		if (!TownySettings.getBedUse()) return; 
+		WorldCoord worldCoord = new WorldCoord(event.getPlayer().getWorld().getName(), Coord.parseCoord(event.getBed().getLocation()));
+        try {
+			boolean isOwner =  worldCoord.getTownBlock().isOwner(TownyUniverse.getDataSource().getResident(event.getPlayer().getName()));
+			if (!isOwner) {
+				event.setCancelled(true);
+				TownyMessaging.sendErrorMsg(event.getPlayer(), "You do not own the land this bed occupies.");
+			}
+		} catch (NotRegisteredException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+	
 	public boolean onPlayerInteract(Player player, Block block, ItemStack item) {
 
 

--- a/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
+++ b/src/com/palmergames/bukkit/towny/permissions/PermissionNodes.java
@@ -145,7 +145,7 @@ public enum PermissionNodes {
 		TOWNY_COMMAND_RESIDENT_TOGGLE_MOBS("towny.command.resident.toggle.mobs"),
 	
 	TOWNY_COMMAND_RESIDENT_FRIEND("towny.command.resident.friend"),
-	
+	TOWNY_COMMAND_RESIDENT_SPAWN("towny.command.resident.spawn"),	
 	
 	/*
 	 * TownyAdmin command permissions

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,6 +1,6 @@
 name: Towny
 main: com.palmergames.bukkit.towny.Towny
-version: 0.84.0.10
+version: 0.84.0.11
 author: Shade, Modified by FuzzeWuzze. Forked by ElgarL
 website: http://code.google.com/a/eclipselabs.org/p/towny/
 description: >


### PR DESCRIPTION
v0.84.0.11:
    - Add config setting to restrict beduse to personally-owned plots only. Found in Resident Settings @ Deny_Bed_Use.
    - If deny_bed_use is true and town_respawn is true, a player will respawn at their bed if there is a bed spawn set.
    - Added new permission node: towny.command.resident.spawn - Allows players to use /resident spawn command.
    - Added new command: /resident spawn - If deny_bed_use: true and player has a current bed spawn, command will teleport player to their bed.
      Behaves according to town spawn command's costs and rules.
