### PR TITLE
Fix ignored result of String.replaceAll()

### DIFF
--- a/src/com/palmergames/util/FileMgmt.java
+++ b/src/com/palmergames/util/FileMgmt.java
@@ -231,7 +231,7 @@ public class FileMgmt {
 
 			//BufferedWriter out = new BufferedWriter(new FileWriter(FileName));
 
-			source.replaceAll("\n", System.getProperty("line.separator"));
+			source = source.replaceAll("\n", System.getProperty("line.separator"));
 
 			out.write(source);
 			out.close();
@@ -428,7 +428,7 @@ public class FileMgmt {
 								}
 							}
 	
-						} catch (Exception e) {
+						} catch (Exception e) {r
 							// Ignore file
 						}
 					}


### PR DESCRIPTION
String.replaceAll() is pointless if the result is ignored
