### PR TITLE
Change the MySQL Command to Fix Errors

### DIFF
--- a/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
+++ b/src/com/palmergames/bukkit/towny/db/TownySQLSource.java
@@ -293,7 +293,7 @@ public class TownySQLSource extends TownyFlatFileSource {
 				// Build the prepared statement string appropriate for
 				// the number of keys/values we are inserting.
 
-				code = "INSERT INTO " + tb_prefix + (tb_name.toUpperCase()) + " ";
+				code = "REPLACE INTO " + tb_prefix + (tb_name.toUpperCase()) + " ";
 				String keycode = "(";
 				String valuecode = " VALUES (";
 


### PR DESCRIPTION
Many people have errors when using MySQL and Towny together. This is because Towny will try INSERT new entries into the database when they already exist.

For instance, if someone changes their Town name, Towny will try to insert the exact town, but with a different name back into the database instead of modifying the current town entry.

I've changed the INSERT INTO SQL command to a REPLACE INTO SQL command. This means it will insert entries into the database, however if they have the same primary key, it will simply UPDATE it. This prevents Towny from creating errors.
